### PR TITLE
Add development docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 .pnp
 .pnp.js
+.pnpm-store
 
 # testing
 /coverage

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,12 @@
+# Dockerfile for local development - see docker-compose-dev.yml for usage instructions
+FROM node:22
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends --assume-yes \
+    curl wget micro htop less bash git
+
+WORKDIR /app
+RUN git config --global --add safe.directory /app
+RUN npm install -g pnpm
+
+EXPOSE 4000

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,45 @@
+# Start a simple dev environment with postgres in docker, and log into web server:
+#
+# `docker compose -f docker-compose-dev.yml --progress=plain up -d && docker exec -ti umami-web-dev-1 bash`
+#
+# From there, install and run like you would locally:
+# 
+# pnpm install
+# npm run build
+# npm run start -- --port 4000
+#
+# Your local directory is mounted into the web container so you can code :)
+# TODO: Files created from within the web container are created as user root - this can cause confusion :(
+#
+# Here's how to shut it all down:
+# `docker compose -f docker-compose-dev.yml --progress=plain down && docker image rm umami-web-dev`
+services:
+  web-dev:
+    build:
+      context: ./
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./:/app
+    ports:
+      - "4000:4000"
+    tty: true
+    environment:
+      NEXT_TELEMETRY_DISABLED: 1
+      DATABASE_URL: postgresql://umami:umami@postgres-dev:5432/umami
+      DATABASE_TYPE: postgresql
+      APP_SECRET: replace-me-with-a-random-string
+    depends_on:
+      - postgres-dev
+  postgres-dev:
+    
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: umami
+      POSTGRES_USER: umami
+      POSTGRES_PASSWORD: umami
+    volumes:
+      - umami_dev_pg_data:/var/lib/postgresql/data
+
+volumes:
+  umami_dev_pg_data:
+    driver: local

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,6 @@
 # Start a simple dev environment with postgres in docker, and log into web server:
 #
-# `docker compose -f docker-compose-dev.yml --progress=plain up -d && docker exec -ti umami-web-dev-1 bash`
+# `env UID=$(id -u) GID=$(id -g) docker compose -f docker-compose-dev.yml --progress=plain up -d && docker exec -ti umami-web-dev-1 bash`
 #
 # From there, install and run like you would locally:
 # 
@@ -9,12 +9,13 @@
 # npm run start -- --port 4000
 #
 # Your local directory is mounted into the web container so you can code :)
-# TODO: Files created from within the web container are created as user root - this can cause confusion :(
+# This uses the same user id and group id as your host system user so file permissions appear to be the same.
 #
 # Here's how to shut it all down:
-# `docker compose -f docker-compose-dev.yml --progress=plain down && docker image rm umami-web-dev`
+# `env UID=$(id -u) GID=$(id -g) docker compose -f docker-compose-dev.yml --progress=plain down && docker image rm umami-web-dev`
 services:
   web-dev:
+    user: "${UID}:${GID}"
     build:
       context: ./
       dockerfile: Dockerfile.dev

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -25,6 +25,9 @@ services:
     tty: true
     environment:
       NEXT_TELEMETRY_DISABLED: 1
+      DISABLE_TELEMETRY: 1
+      ENABLE_TEST_CONSOLE: 1
+      DEBUG: "umami:*"
       DATABASE_URL: postgresql://umami:umami@postgres-dev:5432/umami
       DATABASE_TYPE: postgresql
       APP_SECRET: replace-me-with-a-random-string

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -34,6 +34,7 @@ services:
       APP_SECRET: replace-me-with-a-random-string
     depends_on:
       - postgres-dev
+
   postgres-dev:
     
     image: postgres:15-alpine


### PR DESCRIPTION
First draft of a working local Docker setup for development. I.e. this uses docker-compose to spin up a postgres container and a web/node.js container that mounts the local git checkout and within you can run the usual dev setup.

TODO: Add (initial) package setup to Dockerfile so devs can start immediately (thanks Marco)
DONE: Files created in the mounted volume from within the running container are owned by root:root - which makes it a hassle when working on the host system. There ought to be a way to set up the image so it produces files with the name/user id of the host-system-user